### PR TITLE
 feat(load_index): build query code for combined indexes

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -703,10 +703,20 @@ func (tl TypeLoader) LoadTableIndexes(args *ArgType, typeTpl *Type, ixMap map[st
 			return err
 		}
 
-		// build func name
-		args.BuildIndexFuncName(ixTpl)
-
-		ixMap[typeTpl.Table.TableName+"_"+ix.IndexName] = ixTpl
+		l := len(ixTpl.Fields)
+		for i := 0; i < l; i++ {
+			// fake index according to Leftmost Prefixing for generating query func
+			ixTplNew := &Index{
+				Schema: args.Schema,
+				Type:   typeTpl,
+				Fields: ixTpl.Fields[:l-i],
+				Index:  ix,
+			}
+			// build func name
+			args.BuildIndexFuncName(ixTplNew)
+			// distinct func name
+			ixMap[ixTplNew.FuncName] = ixTplNew
+		}
 	}
 
 	// search for primary key if it was skipped being set in the type

--- a/loaders/mssql.go
+++ b/loaders/mssql.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/knq/snaker"
 
-	"github.com/xo/xo/internal"
+	"github.com/sundayfun/xo/internal"
 	"github.com/xo/xo/models"
 )
 

--- a/loaders/mysql.go
+++ b/loaders/mysql.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/knq/snaker"
 
-	"github.com/xo/xo/internal"
+	"github.com/sundayfun/xo/internal"
 	"github.com/xo/xo/models"
 )
 

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/knq/snaker"
 
-	"github.com/xo/xo/internal"
+	"github.com/sundayfun/xo/internal"
 	"github.com/xo/xo/models"
 )
 

--- a/loaders/sqlite.go
+++ b/loaders/sqlite.go
@@ -6,7 +6,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/xo/xo/internal"
+	"github.com/sundayfun/xo/internal"
 	"github.com/xo/xo/models"
 )
 

--- a/main.go
+++ b/main.go
@@ -16,11 +16,10 @@ import (
 
 	"github.com/alexflint/go-arg"
 
+	"github.com/sundayfun/xo/internal"
+	_ "github.com/sundayfun/xo/loaders"
+	"github.com/sundayfun/xo/models"
 	"github.com/xo/dburl"
-	"github.com/xo/xo/internal"
-	"github.com/xo/xo/models"
-
-	_ "github.com/xo/xo/loaders"
 	_ "github.com/xo/xoutil"
 )
 


### PR DESCRIPTION
- 生成的查询函数根据函数名去重
- 根据组合索引的最左前缀原则生成查询函数，如(a,b,c)组合索引会分别生产a,(a,b),(a,b,c)的查询代码
- 不需要修改模板