### PR TITLE
fix(index): fix index unique problem

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gedex/inflector"
@@ -662,8 +663,14 @@ func (tl TypeLoader) LoadIndexes(args *ArgType, tableMap map[string]*Type) (map[
 		}
 	}
 
+	indexes := make([]*Index, 0, len(ixMap))
+	for _, v := range ixMap {
+		indexes = append(indexes, v)
+	}
+	indexSets := IndexSet(indexes)
+	sort.Sort(indexSets)
 	// generate templates
-	for _, ix := range ixMap {
+	for _, ix := range indexSets {
 		err = args.ExecuteTemplate(IndexTemplate, ix.Type.Name, ix.Index.IndexName, ix)
 		if err != nil {
 			return nil, err
@@ -794,4 +801,16 @@ func (tl TypeLoader) LoadIndexColumns(args *ArgType, ixTpl *Index) error {
 	}
 
 	return nil
+}
+
+func (is IndexSet) Len() int {
+	return len(is)
+}
+
+func (is IndexSet) Swap(i, j int) {
+	is[i], is[j] = is[j], is[i]
+}
+
+func (is IndexSet) Less(i, j int) bool {
+	return strings.Compare(is[i].FuncName, is[j].FuncName) < 0
 }

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -705,12 +705,23 @@ func (tl TypeLoader) LoadTableIndexes(args *ArgType, typeTpl *Type, ixMap map[st
 
 		l := len(ixTpl.Fields)
 		for i := 0; i < l; i++ {
+			index := &models.Index{
+				IndexName: ix.IndexName,
+				IsUnique:  ix.IsUnique,
+				IsPrimary: ix.IsPrimary,
+				SeqNo:     ix.SeqNo,
+				Origin:    ix.Origin,
+				IsPartial: ix.IsPartial,
+			}
+			if i > 0 {
+				index.IsUnique = false
+			}
 			// fake index according to Leftmost Prefixing for generating query func
 			ixTplNew := &Index{
 				Schema: args.Schema,
 				Type:   typeTpl,
 				Fields: ixTpl.Fields[:l-i],
-				Index:  ix,
+				Index:  index,
 			}
 			// build func name
 			args.BuildIndexFuncName(ixTplNew)

--- a/internal/types.go
+++ b/internal/types.go
@@ -141,6 +141,8 @@ type ForeignKey struct {
 	Comment    string
 }
 
+type IndexSet []*Index
+
 // Index is a template item for a index into a table.
 type Index struct {
 	FuncName string


### PR DESCRIPTION
- 在生成前缀索引的部分的查询代码时，忽略了索引的isUnique对结果的影响。
- 例见 https://github.com/sundayfun/daycam-server/pull/1216
- 生成的代码因为函数顺序不一致，会导致每次生成的代码不一样，这里根据function name做一下排序