### PR TITLE
feat(err_message): return more err message

### DIFF
--- a/main.go
+++ b/main.go
@@ -357,7 +357,7 @@ func writeTypes(args *internal.ArgType) error {
 	// process written files with goimports
 	output, err := exec.Command("goimports", params...).CombinedOutput()
 	if err != nil {
-		return errors.New(string(output))
+		return fmt.Errorf("%s with error message: %s", output, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
- 执行goimports时，应该带上err的错误信息，不然如果没有安装goimports会没有错误信息，不好排查问题。