### PR TITLE
feat/xo: handle is_deleted field

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -542,6 +542,10 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 			typeTpl.PrimaryKey = f
 		}
 
+		if c.ColumnName == "is_deleted" && f.Type == "bool" {
+			typeTpl.HasDeletedField = true
+		}
+
 		// append col to template fields
 		typeTpl.Fields = append(typeTpl.Fields, f)
 	}

--- a/internal/types.go
+++ b/internal/types.go
@@ -127,6 +127,7 @@ type Type struct {
 	Fields           []*Field
 	Table            *models.Table
 	Comment          string
+	HasDeletedField  bool
 }
 
 // ForeignKey is a template item for a foreign relationship on a table.


### PR DESCRIPTION
- 支持对表中包含 `is_deleted` 字段时，生成的查询语句的处理
- 配合模板的修改，达到具体如下效果（如果表中未包含`is_deleted`字段，则相比以前没有任何变化）：
> 1. select/update 语句中增加条件 `AND is_deleted = false`
> 2. delete 语句中改成 `UPDATE xxx SET is_deleted = true WHERE xxx`
> 3. 增加一个 RecoverRowContext 函数，效果跟 delete 语句相反，语句为 `UPDATE xxx SET is_deleted = false WHERE xxx`