### PR TITLE
feat(map_func): load query map func

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -37,6 +37,7 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"hasfield":           a.hasfield,
 		"getstartcount":      a.getstartcount,
 		"pluralize":          a.pluralize,
+		"snaketocamel":       a.snaketocamel,
 	}
 }
 
@@ -747,4 +748,8 @@ func (a *ArgType) getstartcount(fields []*Field, pkFields []*Field) int {
 
 func (a *ArgType) pluralize(name string) string {
 	return inflector.Pluralize(name)
+}
+
+func (a *ArgType) snaketocamel(name string) string {
+	return snaker.ForceLowerCamelIdentifier(name)
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -12,6 +12,7 @@ const (
 	TypeTemplate
 	ForeignKeyTemplate
 	IndexTemplate
+	MapTemplate
 	QueryTypeTemplate
 	QueryTemplate
 
@@ -35,6 +36,8 @@ func (tt TemplateType) String() string {
 		s = "foreignkey"
 	case IndexTemplate:
 		s = "index"
+	case MapTemplate:
+		s = "map"
 	case QueryTypeTemplate:
 		s = "querytype"
 	case QueryTemplate:
@@ -63,6 +66,13 @@ const (
 	SchemaEsc = iota
 	TableEsc
 	ColumnEsc
+)
+
+type LoadType uint
+
+const (
+	LoadQueryFunc = iota
+	LoadMapFunc
 )
 
 // String provides the string representation of RelType.
@@ -144,12 +154,14 @@ type ForeignKey struct {
 
 // Index is a template item for a index into a table.
 type Index struct {
-	FuncName string
-	Schema   string
-	Type     *Type
-	Fields   []*Field
-	Index    *models.Index
-	Comment  string
+	FuncName    string
+	MapFuncName string
+	MapField    *Field
+	Schema      string
+	Type        *Type
+	Fields      []*Field
+	Index       *models.Index
+	Comment     string
 }
 
 // QueryParam is a query parameter for a custom query.

--- a/internal/util.go
+++ b/internal/util.go
@@ -181,6 +181,22 @@ func (a *ArgType) BuildIndexFuncName(ixTpl *Index) {
 	ixTpl.FuncName = funcName + strings.Join(paramNames, "")
 }
 
+// BuildIndexMapFuncName builds the index map func name for an index and its supplied
+// fields.
+func (a *ArgType) BuildIndexMapFuncName(ixTpl *Index) {
+	// build map func name
+	mapFuncName := inflector.Pluralize(ixTpl.Type.Name) + "Map"
+	mapFuncName = mapFuncName + "By"
+
+	// add param names
+	if len(ixTpl.Fields) >= 1 {
+		mapField := ixTpl.Fields[len(ixTpl.Fields)-1]
+		ixTpl.MapField = mapField
+		ixTpl.MapFuncName = mapFuncName + inflector.Pluralize(mapField.Name)
+	}
+	// store resulting name back
+}
+
 // letters for GenRandomID
 var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 


### PR DESCRIPTION
- 添加一类方法，根据某字段数组使用 in 查询 row，返回一个 map，类似 usersMapByUserIDs
- 目前会为唯一索引，且索引中只包含一个字段的添加该方法，如 session 表中有 id 索引和UNIQUE KEY `uni_token` (`token`), UNIQUE KEY `DEVICE_ID_IDX` (`device_id`),  KEY `ind_user_id` (`user_id`), KEY `idx_llt` (`last_login_time`)索引，则会生成三个方法：SessionsMapByDeviceIDsContext、SessionsMapByIDsContext、SessionsMapByTokensContext。其中SessionsMapByTokensContext 的方法具体如下：

```
// SessionsMapByTokensContext retrieves a map with key: Token, value: Session.
func SessionsMapByTokensContext(ctx context.Context, db XODB, Tokens []string) (map[string]*Session, error) {
	if len(Tokens) == 0 {
		return nil, nil
	}

	// sql query
	const sqlstr = "SELECT " +
		"id, user_id, token, device_token, type, env, lang, last_login_time, expire_hours, last_app_version, need_init, device_id, channel, created_at, user_agent " +
		"FROM session " +
		"WHERE token IN(?)"

	q, args, err := sqlx.In(sqlstr, Tokens)
	if err != nil {
		return nil, err
	}

	sessions := make([]*Session, 0, len(Tokens))
	err = sqlx.SelectContext(ctx, db, &sessions, q, args...)
	if err != nil {
		return nil, err
	}

	m := make(map[string]*Session, len(Tokens))

	for _, session := range sessions {
		m[session.Token] = session
	}

	return m, nil
}

```

- SessionsMapByTokensContext 不会判断要查询的某个 token 是否存在，而是需要在调用得到 map 后自行判断。