### PR TITLE
feat(xo): generate proto and model convert to pb function

### DIFF
--- a/config/example.yml
+++ b/config/example.yml
@@ -1,0 +1,10 @@
+list_fields:
+model_to_pb:
+  user: # service
+    - # model
+      name: user
+      skip:
+        - password
+    -
+      name: user_ads
+      skip:

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZp
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -144,6 +144,9 @@ type ArgType struct {
 	// Generated is the generated templates after a run.
 	Generated []TBuf `arg:"-"`
 
+	// Generated is the generated proto templates after a run.
+	GeneratedProto []TBuf `arg:"-"`
+
 	// KnownTypeMap is the collection of known Go types.
 	KnownTypeMap map[string]bool `arg:"-"`
 
@@ -159,6 +162,20 @@ type ArgType struct {
 
 	// parsed from MethodsConfigFile
 	Methods *MethodsConfig `arg:"-"`
+
+	// eg. github.com/sundayfun/rpc/proto/backend/service
+	RpcProtoPathPrefix string `arg:"--rpc-proto-path-prefix"`
+
+	// eg. github.com/sundayfun/daycam-server/backend
+	ServerProtoPathPrefix string `arg:"--server-proto-path-prefix"`
+
+	Imports []string `agr:"-"`
+
+	ToPBTypeMap map[string]string `arg:"-"`
+
+	WrapperTypeMap map[string]string `arg:"-"`
+
+	ImportMap map[string]string `arg:"-"`
 }
 
 // NewDefaultArgs returns the default arguments.
@@ -222,6 +239,33 @@ func NewDefaultArgs() *ArgType {
 			"Point":        true,
 			"Polygon":      true,
 			"MultiPolygon": true,
+		},
+
+		ServerProtoPathPrefix: "github.com/sundayfun/daycam-server/backend",
+
+		// TODO: @kippa 目前还没有处理 geo 相关类型
+		ToPBTypeMap: map[string]string{
+			"int8":   "int32",
+			"uint8":  "uint32",
+			"int16":  "int32",
+			"uint16": "uint32",
+			"int":    "int32",
+			"uint":   "uint32",
+		},
+
+		WrapperTypeMap: map[string]string{
+			"sql.NullString":  "StringValue",
+			"sql.NullInt64":   "Int64Value",
+			"sql.NullFloat64": "FloatValue",
+			"sql.NullBool":    "BoolValue",
+		},
+
+		ImportMap: map[string]string{
+			"sql.NullString":  "google/protobuf/wrappers.proto",
+			"sql.NullInt64":   "google/protobuf/wrappers.proto",
+			"sql.NullFloat64": "google/protobuf/wrappers.proto",
+			"sql.NullBool":    "google/protobuf/wrappers.proto",
+			"mysql.NullTime":  "google/protobuf/timestamp.proto",
 		},
 	}
 }

--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -38,6 +39,9 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"getstartcount":      a.getstartcount,
 		"pluralize":          a.pluralize,
 		"snaketocamel":       a.snaketocamel,
+		"modelToPB":          a.modelToPB,
+		"PBToModel":          a.PBToModel,
+		"proto":              a.proto,
 	}
 }
 
@@ -752,4 +756,249 @@ func (a *ArgType) pluralize(name string) string {
 
 func (a *ArgType) snaketocamel(name string) string {
 	return snaker.ForceLowerCamelIdentifier(name)
+}
+
+func (a *ArgType) modelToPB(option *MethodsOption) string {
+	if !option.ModelToPB {
+		return ""
+	}
+	var body, shortName string
+
+	fieldsAssignment := make([]string, 0, len(option.Type.Fields))
+
+	shortName = a.shortname(option.Type.Name)
+
+	for _, field := range option.Type.Fields {
+		if _, ok := option.ModelToPBConfig.SkipFields[field.Col.ColumnName]; ok {
+			continue
+		}
+		if !field.Col.NotNull {
+			continue
+		}
+		var f, fa string
+		if field.Type == "time.Time" {
+			f = snaker.ForceLowerCamelIdentifier(field.Col.ColumnName)
+			body = body + fmt.Sprintf(
+				`%s, err := ptypes.TimestampProto(%s.%s)
+	if err != nil {
+		return nil, err
+	}
+`, f, shortName, field.Name)
+			fa = fmt.Sprintf(`%s:%s,`, SnakeToCamelWithoutInitialisms(field.Col.ColumnName), f)
+		} else {
+			if t, ok := a.ToPBTypeMap[field.Type]; ok {
+				fa = fmt.Sprintf(`%s:%s(%s.%s),`, SnakeToCamelWithoutInitialisms(field.Col.ColumnName),
+					t, shortName, field.Name)
+			} else {
+				fa = fmt.Sprintf(`%s:%s.%s,`, SnakeToCamelWithoutInitialisms(field.Col.ColumnName),
+					shortName, field.Name)
+			}
+		}
+		fieldsAssignment = append(fieldsAssignment, fa)
+	}
+	body = body + fmt.Sprintf(
+		`proto%s := &proto.%s{
+	%s
+}
+`, option.Type.Name, option.Type.Name, strings.Join(fieldsAssignment, "\n"))
+	for _, field := range option.Type.Fields {
+		if field.Col.NotNull {
+			continue
+		}
+		if _, ok := option.ModelToPBConfig.SkipFields[field.Col.ColumnName]; ok {
+			continue
+		}
+		var s, fa string
+		s = SnakeToCamelWithoutInitialisms(field.Col.ColumnName)
+		if field.Type == "mysql.NullTime" {
+			f := snaker.ForceLowerCamelIdentifier(field.Col.ColumnName)
+			fa = fmt.Sprintf(
+				`if %s.%s.Valid {
+	%s, err := ptypes.TimestampProto(%s.%s.Time)
+	if err != nil {
+		return nil, err
+	}
+	proto%s.%s = %s
+}
+`, shortName, field.Name,
+				f, shortName, field.Name,
+				option.Type.Name, s, f)
+		} else {
+			if typ, ok := a.WrapperTypeMap[field.Type]; ok {
+				fa = fmt.Sprintf(
+					`if %s.%s.Valid {
+	proto%s.%s = &wrappers.%s{Value:%s.%s.%s}
+}
+`, shortName, field.Name, option.Type.Name, s, typ, shortName, field.Name, strings.Trim(typ, "Value"))
+			}
+		}
+		body = body + fa
+	}
+
+	body = body + fmt.Sprintf("\nreturn proto%s, nil", option.Type.Name)
+	return body
+}
+
+func (a *ArgType) PBToModel(option *MethodsOption) string {
+	if !option.ModelToPB {
+		return ""
+	}
+	var body, shortName string
+
+	fieldsAssignment := make([]string, 0, len(option.Type.Fields))
+
+	shortName = a.shortname(option.Type.Name)
+
+	for _, field := range option.Type.Fields {
+		if _, ok := option.ModelToPBConfig.SkipFields[field.Col.ColumnName]; ok {
+			continue
+		}
+		if !field.Col.NotNull {
+			continue
+		}
+		var f, fa string
+		if field.Type == "time.Time" {
+			f = snaker.ForceLowerCamelIdentifier(field.Col.ColumnName)
+			body = body + fmt.Sprintf(
+				`%s, err := ptypes.Timestamp(proto%s.%s)
+	if err != nil {
+		return nil, err
+	}
+`, f, option.Type.Name, field.Name)
+			fa = fmt.Sprintf(`%s:%s,`, field.Name, f)
+		} else {
+			if _, ok := a.ToPBTypeMap[field.Type]; ok {
+				fa = fmt.Sprintf(`%s:%s(proto%s.%s),`, field.Name, field.Type, option.Type.Name,
+					SnakeToCamelWithoutInitialisms(field.Col.ColumnName))
+			} else {
+				fa = fmt.Sprintf(`%s:proto%s.%s,`, field.Name, option.Type.Name,
+					SnakeToCamelWithoutInitialisms(field.Col.ColumnName))
+			}
+		}
+		fieldsAssignment = append(fieldsAssignment, fa)
+	}
+
+	body = body + fmt.Sprintf(
+		`%s := &%s{
+	%s
+}
+`, shortName, option.Type.Name, strings.Join(fieldsAssignment, "\n"))
+
+	for _, field := range option.Type.Fields {
+		if _, ok := option.ModelToPBConfig.SkipFields[field.Col.ColumnName]; ok {
+			continue
+		}
+		if field.Col.NotNull {
+			continue
+		}
+		var s, fa string
+		s = SnakeToCamelWithoutInitialisms(field.Col.ColumnName)
+		if field.Type == "mysql.NullTime" {
+			f := snaker.ForceLowerCamelIdentifier(field.Col.ColumnName)
+			fa = fmt.Sprintf(
+				`if proto%s.%s != nil {
+	%s, err := ptypes.Timestamp(proto%s.%s)
+	if err != nil {
+		return nil, err
+	}
+	%s.%s = mysql.NullTime{Time:%s, Valid:true}
+}
+`, option.Type.Name, s,
+				f, option.Type.Name, s,
+				shortName, field.Name, f)
+		} else {
+			if typ, ok := a.WrapperTypeMap[field.Type]; ok {
+				fa = fmt.Sprintf(
+					`if proto%s.%s != nil {
+	%s.%s = %s{%s:proto%s.%s.Value, Valid:true}
+}
+`, option.Type.Name, s, shortName, field.Name, field.Type, strings.Trim(typ, "Value"), option.Type.Name, s)
+			}
+		}
+		body = body + fa
+	}
+
+	body = body + fmt.Sprintf("\nreturn %s, nil", shortName)
+	return body
+}
+
+func (a *ArgType) proto(pc ProtoConfig) string {
+	if len(pc) == 0 {
+		return ""
+	}
+	sort.Stable(pc)
+
+	svc := pc[0].ModelToPBConfig.ImportService
+	var body string
+
+	imports := make([]string, 0)
+	m := make(map[string]struct{}, 0)
+	for _, p := range pc {
+		for _, f := range p.Type.Fields {
+			if _, ok := p.ModelToPBConfig.SkipFields[f.Col.ColumnName]; ok {
+				continue
+			}
+			if i, ok := a.ImportMap[f.Type]; ok {
+				if _, ok = m[i]; ok {
+					continue
+				}
+				m[i] = struct{}{}
+				imports = append(imports, fmt.Sprintf(`import "%s";`, i))
+			}
+		}
+	}
+
+	body = body + fmt.Sprintf(
+		`package proto.%s;
+
+%s
+
+option go_package = "%s/%s/proto";
+option java_multiple_files = true;
+option objc_class_prefix = "RPC";
+`, svc, strings.Join(imports, "\n"), a.ServerProtoPathPrefix, svc)
+
+	for _, p := range pc {
+		fieldsDef := make([]string, 0, len(p.Type.Fields))
+		count := 1
+		for _, f := range p.Type.Fields {
+			if _, ok := p.ModelToPBConfig.SkipFields[f.Col.ColumnName]; ok {
+				continue
+			}
+			def := fmt.Sprintf("\t%s %s = %d;", f.Type, f.Col.ColumnName, count)
+			if v, ok := a.ToPBTypeMap[f.Type]; ok {
+				def = fmt.Sprintf("\t%s %s = %d;", v, f.Col.ColumnName, count)
+			}
+			if v, ok := a.WrapperTypeMap[f.Type]; ok {
+				def = fmt.Sprintf("\tgoogle.protobuf.%s %s = %d;", v, f.Col.ColumnName, count)
+			}
+			if f.Type == "mysql.NullTime" || f.Type == "time.Time" {
+				def = fmt.Sprintf("\tgoogle.protobuf.Timestamp %s = %d;", f.Col.ColumnName, count)
+			}
+			if f.Comment != "" {
+				def = fmt.Sprintf("%s\n%s", f.Comment, def)
+			}
+			fieldsDef = append(fieldsDef, def)
+			count++
+		}
+		body = body + fmt.Sprintf(
+			`message %s {
+%s
+}
+`, p.Type.Name, strings.Join(fieldsDef, "\n"))
+	}
+	return body
+}
+
+// proto 对于 id -> Id
+func SnakeToCamelWithoutInitialisms(str string) string {
+	var r string
+
+	for _, w := range strings.Split(str, "_") {
+		if w == "" {
+			continue
+		}
+		r += strings.ToUpper(w[:1]) + strings.ToLower(w[1:])
+	}
+	return r
 }

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -196,7 +196,7 @@ func (tl TypeLoader) ParseQuery(args *ArgType) error {
 	}
 
 	// generate query type template
-	err = args.ExecuteTemplate(QueryTypeTemplate, args.QueryType, "", typeTpl)
+	err = args.ExecuteTemplate(QueryTypeTemplate, args.QueryType, "", typeTpl, false)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func (tl TypeLoader) ParseQuery(args *ArgType) error {
 	}
 
 	// generate template
-	err = args.ExecuteTemplate(QueryTemplate, args.QueryType, "", queryTpl)
+	err = args.ExecuteTemplate(QueryTemplate, args.QueryType, "", queryTpl, false)
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func (tl TypeLoader) LoadEnums(args *ArgType) (map[string]*Enum, error) {
 
 	// generate enum templates
 	for _, e := range enumMap {
-		err = args.ExecuteTemplate(EnumTemplate, e.Name, "", e)
+		err = args.ExecuteTemplate(EnumTemplate, e.Name, "", e, false)
 		if err != nil {
 			return nil, err
 		}
@@ -424,7 +424,7 @@ func (tl TypeLoader) LoadProcs(args *ArgType) (map[string]*Proc, error) {
 
 	// generate proc templates
 	for _, p := range procMap {
-		err = args.ExecuteTemplate(ProcTemplate, "sp_"+p.Name, "", p)
+		err = args.ExecuteTemplate(ProcTemplate, "sp_"+p.Name, "", p, false)
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +498,7 @@ func (tl TypeLoader) LoadRelkind(args *ArgType, relType RelType) (map[string]*Ty
 
 	// generate table templates
 	for _, t := range tableMap {
-		err = args.ExecuteTemplate(TypeTemplate, t.Name, "", t)
+		err = args.ExecuteTemplate(TypeTemplate, t.Name, "", t, false)
 		if err != nil {
 			return nil, err
 		}
@@ -582,7 +582,7 @@ func (tl TypeLoader) LoadForeignKeys(args *ArgType, tableMap map[string]*Type) (
 
 	// generate templates
 	for _, fk := range fkMap {
-		err = args.ExecuteTemplate(ForeignKeyTemplate, fk.Type.Name, fk.ForeignKey.ForeignKeyName, fk)
+		err = args.ExecuteTemplate(ForeignKeyTemplate, fk.Type.Name, fk.ForeignKey.ForeignKeyName, fk, false)
 		if err != nil {
 			return nil, err
 		}
@@ -677,7 +677,7 @@ func (tl TypeLoader) LoadIndexes(args *ArgType, tableMap map[string]*Type) (map[
 
 	// generate templates
 	for _, ix := range ixMap {
-		err = args.ExecuteTemplate(IndexTemplate, ix.Type.Name, ix.FuncName, ix)
+		err = args.ExecuteTemplate(IndexTemplate, ix.Type.Name, ix.FuncName, ix, false)
 		if err != nil {
 			return nil, err
 		}
@@ -691,31 +691,64 @@ func (tl TypeLoader) LoadOptionalMethods(args *ArgType, tableMap map[string]*Typ
 	if args.Methods == nil {
 		return nil
 	}
-	m1 := make(map[string]struct{}, len(args.Methods.ListFields))
+	listFieldsMap := make(map[string]struct{}, len(args.Methods.ListFields))
 	for _, c := range args.Methods.ListFields {
-		m1[c] = struct{}{}
+		listFieldsMap[c] = struct{}{}
+	}
+	modelToPBMap := make(map[string]*ModelToPBConfig, len(args.Methods.ModelToPB))
+	for s, c := range args.Methods.ModelToPB {
+		for _, m := range c {
+			skips := make(map[string]struct{}, len(m.Skip))
+			for _, skip := range m.Skip {
+				skips[skip] = struct{}{}
+			}
+			modelToPBMap[m.Name] = &ModelToPBConfig{
+				ImportService: s,
+				SkipFields:    skips,
+			}
+		}
 	}
 
-	fm := map[string]*MethodsOption{}
+	mos := map[string]*MethodsOption{}
+	pcs := map[string]ProtoConfig{}
 	for tableName, t := range tableMap {
 		option := &MethodsOption{
 			Type: t,
 			Sub:  fmt.Sprintf("%sOptional", t.Name),
 		}
-		if _, ok := m1[tableName]; ok {
+		if _, ok := listFieldsMap[tableName]; ok {
 			option.ListFields = true
 		}
-		if option.ListFields {
-			fm[tableName] = option
+		if s, ok := modelToPBMap[tableName]; ok {
+			option.ModelToPB = true
+			option.ModelToPBConfig = s
+			args.Imports = append(args.Imports, fmt.Sprintf("%s/%s/proto", args.ServerProtoPathPrefix, s.ImportService))
+			if _, ok := pcs[s.ImportService]; ok {
+				pcs[s.ImportService] = append(pcs[s.ImportService], option)
+			} else {
+				pcs[s.ImportService] = ProtoConfig{option}
+			}
+		}
+
+		if option.ListFields || option.ModelToPB {
+			mos[tableName] = option
 		}
 	}
-	for _, f := range fm {
+	for _, m := range mos {
 		// generate templates
-		err := args.ExecuteTemplate(OptionalTemplate, f.Type.Name, f.Sub, f)
+		err := args.ExecuteTemplate(OptionalTemplate, m.Type.Name, m.Sub, m, false)
 		if err != nil {
 			return err
 		}
 	}
+
+	for svc, pc := range pcs {
+		err := args.ExecuteTemplate(TypeProtoTemplate, svc, svc, pc, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -734,7 +767,7 @@ func (tl TypeLoader) LoadIndexesQueryMapFunc(args *ArgType, tableMap map[string]
 
 	// generate templates
 	for _, ix := range ixMap {
-		err = args.ExecuteTemplate(MapTemplate, ix.Type.Name, ix.MapFuncName, ix)
+		err = args.ExecuteTemplate(MapTemplate, ix.Type.Name, ix.MapFuncName, ix, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/templates.go
+++ b/internal/templates.go
@@ -36,7 +36,7 @@ func (a *ArgType) TemplateSet() *TemplateSet {
 
 // ExecuteTemplate loads and parses the supplied template with name and
 // executes it with obj as the context.
-func (a *ArgType) ExecuteTemplate(tt TemplateType, name string, sub string, obj interface{}) error {
+func (a *ArgType) ExecuteTemplate(tt TemplateType, name string, sub string, obj interface{}, isProto bool) error {
 	var err error
 
 	// setup generated
@@ -63,7 +63,12 @@ func (a *ArgType) ExecuteTemplate(tt TemplateType, name string, sub string, obj 
 			loaderType = a.LoaderType + "."
 		}
 	}
-	templateName := fmt.Sprintf("%s%s.go.tpl", loaderType, tt)
+	templateName := ""
+	if isProto {
+		templateName = fmt.Sprintf("%s%s.proto.tpl", loaderType, tt)
+	} else {
+		templateName = fmt.Sprintf("%s%s.go.tpl", loaderType, tt)
+	}
 
 	// execute template
 	err = a.TemplateSet().Execute(v.Buf, templateName, obj)
@@ -71,7 +76,11 @@ func (a *ArgType) ExecuteTemplate(tt TemplateType, name string, sub string, obj 
 		return err
 	}
 
-	a.Generated = append(a.Generated, v)
+	if isProto {
+		a.GeneratedProto = append(a.GeneratedProto, v)
+	} else {
+		a.Generated = append(a.Generated, v)
+	}
 	return nil
 }
 

--- a/internal/types.go
+++ b/internal/types.go
@@ -1,6 +1,10 @@
 package internal
 
-import "github.com/xo/xo/models"
+import (
+	"strings"
+
+	"github.com/xo/xo/models"
+)
 
 // TemplateType represents a template type.
 type TemplateType uint
@@ -16,6 +20,7 @@ const (
 	QueryTypeTemplate
 	QueryTemplate
 	OptionalTemplate
+	TypeProtoTemplate
 
 	// always last
 	XOTemplate
@@ -45,6 +50,8 @@ func (tt TemplateType) String() string {
 		s = "query"
 	case OptionalTemplate:
 		s = "optional"
+	case TypeProtoTemplate:
+		s = "type"
 	default:
 		panic("unknown TemplateType")
 	}
@@ -93,7 +100,13 @@ func (rt RelType) String() string {
 }
 
 type MethodsConfig struct {
-	ListFields []string `yaml:"list_fields"`
+	ListFields []string                  `yaml:"list_fields"`
+	ModelToPB  map[string][]*TableConfig `yaml:"model_to_pb"`
+}
+
+type TableConfig struct {
+	Name string   `yaml:"name"`
+	Skip []string `yaml:"skip"`
 }
 
 // EnumValue holds data for a single enum value.
@@ -172,9 +185,30 @@ type Index struct {
 }
 
 type MethodsOption struct {
-	Type       *Type
-	Sub        string
-	ListFields bool
+	Type            *Type
+	Sub             string
+	ListFields      bool
+	ModelToPB       bool
+	ModelToPBConfig *ModelToPBConfig
+}
+
+type ModelToPBConfig struct {
+	ImportService string
+	SkipFields    map[string]struct{}
+}
+
+type ProtoConfig []*MethodsOption
+
+func (t ProtoConfig) Len() int {
+	return len(t)
+}
+
+func (t ProtoConfig) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+func (t ProtoConfig) Less(i, j int) bool {
+	return strings.Compare(t[i].Sub, t[j].Sub) < 0
 }
 
 // QueryParam is a query parameter for a custom query.

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	_ "github.com/xo/xoutil"
 )
 
-const version = "1.0.0"
+const version = "1.0.1"
 
 func main() {
 	// circumvent all logic to just determine if xo was built with oracle


### PR DESCRIPTION
- 根据配置为 service 生成 model 的 proto 到 rpc 指定目录下，并在 xx.xo.go file 中提供 model 和 pb 之间转换的方法。
- 配置示例：

```
list_fields:
model_to_pb:
  user: # service
    - 
      name: user # model
      skip:
        - password # will ignore password field
    -
      name: user_ads
      skip:
```

- 结构：

```
type MethodsConfig struct {
	ListFields []string                  `yaml:"list_fields"`
	ModelToPB  map[string][]*TableConfig `yaml:"model_to_pb"`
}

type TableConfig struct {
	Name string   `yaml:"name"`
	Skip []string `yaml:"skip"`
}
```

- RpcProtoPathPrefix 和 ServerProtoPathPrefix 有默认值，也可以在 xo 参数中配置。