### PR TITLE
fix(xo): compatbile for group

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -147,7 +147,7 @@ func (tl TypeLoader) ParseQuery(args *ArgType) error {
 
 	// create template for query type
 	typeTpl := &Type{
-		Name:    args.QueryType,
+		Name:    GroupCompatible(args, args.QueryType),
 		RelType: Table,
 		Fields:  []*Field{},
 		Table: &models.Table{
@@ -493,7 +493,7 @@ func (tl TypeLoader) LoadRelkind(args *ArgType, relType RelType) (map[string]*Ty
 
 		// create template
 		typeTpl := &Type{
-			Name:    SingularizeIdentifier(ti.TableName),
+			Name:    GroupCompatible(args, SingularizeIdentifier(ti.TableName)),
 			Schema:  args.Schema,
 			RelType: relType,
 			Fields:  []*Field{},

--- a/internal/util.go
+++ b/internal/util.go
@@ -238,6 +238,14 @@ func SingularizeIdentifier(s string) string {
 	return snaker.SnakeToCamelIdentifier(s)
 }
 
+// 因为有个服务的名字叫 Group 和 Group Service 冲突了，这里改为 MGroup
+func GroupCompatible(args *ArgType, name string) string {
+	if len(args.RpcProtoPathPrefix) > 0 && name == "Group" {
+		return "MGroup"
+	}
+	return name
+}
+
 // TBuf is to hold the executed templates.
 type TBuf struct {
 	TemplateType TemplateType


### PR DESCRIPTION
因为 Group model 生成的 proto （在 GroupService 内的）会跟 unary 的 Group Service 冲突，这里改为 MGroup。